### PR TITLE
add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+
+[*.py]
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+max_line_length = 100


### PR DESCRIPTION
EditorConfig is very well known config file for text editors/IDE's
with settings for project. This format supported by Vim, GNOME Builder,
Atom, Sublime and many others.

We will provide this configuration to be more friendly for newcomers.
