### PR TITLE
add 'latest-tag' support

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,15 +51,17 @@ You must set one or both from `git`/`distgit`.
 
 #### `git` structure:
 
-| Parameter | Required | Type | Comments                                    |
-|-----------|----------|------|---------------------------------------------|
-| src       | yes      | str  | URL to git repo (can use aliases set above) |
-| freeze    | no       | str  | Commit to freeze repo on                    |
-| branch    | no       | str  | Branch to freeze repo on                    |
+| Parameter  | Required | Type | Comments                                    |
+|------------|----------|------|---------------------------------------------|
+| src        | yes      | str  | URL to git repo (can use aliases set above) |
+| freeze     | no       | str  | Commit to freeze repo on                    |
+| branch     | no       | str  | Branch to freeze repo on                    |
+| latest-tag | no       | bool | Find latest tag from used branch and use it |
 
-Only one of following parameters can be chosen:
-* `freeze`
-* `branch`
+1. `freeze` or `branch` can be used at the same time
+2. `freeze` or `latest-tag` can be used at the same time
+
+In case `latest-tag` is `True` and there are no git tags in used branch - exception will be raised.
 
 #### `distgit` structure:
 


### PR DESCRIPTION
Allow building from latest git tag from branch. It's good when you want
to build overlay for stable versions without specifying each version for
each component.
