### PR TITLE
 Correctly handle branches for spec file 

### DIFF
--- a/rgo/component.py
+++ b/rgo/component.py
@@ -59,11 +59,19 @@ class Component(object):
         assert self.cloned
         import rpm
         if self.distgit:
-            spec = os.path.join(self.distgit.cwd, "{!s}.spec".format(self.name))
+            spec_git = self.distgit
+            spec_name = "{!s}.spec".format(self.name)
             patches = self.distgit.patches
         else:
-            spec = os.path.join(self.git.cwd, self.git.spec_path or "{!s}.spec".format(self.name))
+            spec_git = self.git
+            spec_name = self.git.spec_path or "{!s}.spec".format(self.name)
             patches = PatchesAction.keep
+
+        # extract spec file from specified branch and save it in temporary location
+        spec = os.path.join(cwd, "original.spec")
+        with open(spec, "w") as f_spec:
+            subprocess.run(["git", "cat-file", "-p", "{}:{}".format(spec_git.ref, spec_name)],
+                           cwd=spec_git.cwd, check=True, stdout=f_spec)
 
         rpmspec = rpm.spec(spec)
         _name = rpmspec.sourceHeader["Name"]

--- a/rgo/component.py
+++ b/rgo/component.py
@@ -66,8 +66,10 @@ class Component(object):
             patches = PatchesAction.keep
 
         rpmspec = rpm.spec(spec)
-        _spec_path = os.path.join(cwd,
-                                  "{!s}.spec".format(rpmspec.sourceHeader["Name"].decode("utf-8")))
+        _name = rpmspec.sourceHeader["Name"]
+        if isinstance(_name, bytes):
+            _name = _name.decode("utf-8")
+        _spec_path = os.path.join(cwd, "{!s}.spec".format(_name))
         if self.git:
             # Get version and release
             version, release = self.git.describe(self.name)
@@ -75,7 +77,9 @@ class Component(object):
             # If spec is located in upstream it's possible that version can be changed
             # which means we also should align it here
             if not self.distgit:
-                _version = rpmspec.sourceHeader["Version"].decode("utf-8")
+                _version = rpmspec.sourceHeader["Version"]
+                if isinstance(_version, bytes):
+                    _version = _version.decode("utf-8")
                 LOGGER.debug("Version in upstream spec file: %r", _version)
                 if rpm.labelCompare((None, _version, None), (None, version, None)) == 1:
                     # Version in spec > than from git tags


### PR DESCRIPTION
Currently rpm-gitoverlay only takes spec file from master branch (either of distgit or git). With this patch it correctly follows branches as they are configured in overlay.yml.