### PR TITLE
Fix the --with option

### DIFF
--- a/rgo/__main__.py
+++ b/rgo/__main__.py
@@ -69,7 +69,13 @@ def add_build_actions(parser):
     )
 
     rpm_parser = argparse.ArgumentParser(add_help=False)
-    chroot_parser.add_argument("--with", help="space-separated rpmbuild --with options to use", dest="build_with")
+    rpm_parser.add_argument(
+        "--with",
+        help="space-separated rpmbuild --with options to use",
+        dest="build_with",
+        default=""
+    )
+
     builder = rpm_parser.add_subparsers(help="Builder", dest="builder")
     builder.required = True
     builder.add_parser("rpmbuild", help="Build using rpmbuild")


### PR DESCRIPTION
Set default for the --with option to "", as we are calling a strip() on
it.

Also set the option to the rpm_parser, where it belongs, not the
chroot_parser.