### PR TITLE
Don't show generated projects on Copr homepage

### DIFF
--- a/rgo/builders/copr.py
+++ b/rgo/builders/copr.py
@@ -83,7 +83,8 @@ class CoprBuilder(object):
                 self.chroots,
                 enable_net=self.enable_net,
                 delete_after_days=delete_after_days,
-                additional_repos=additional_repos
+                additional_repos=additional_repos,
+                unlisted_on_hp=True
             )
             LOGGER.info("Created COPR project: %s/%s", self.project.ownername, self.project.name)
 


### PR DESCRIPTION
Since we generate new projects quite often (for each PR) we shouldn't
spam the Copr homepage with them.

I think we can hard-code this but if an additional option for rgo would be preferred I can add it.