### PR TITLE
Don't override `failed` var when checking each build

### DIFF
--- a/rgo/__main__.py
+++ b/rgo/__main__.py
@@ -94,7 +94,7 @@ def add_build_actions(parser):
     )
     copr.add_argument(
         "--no-wait",
-        help="Don't wait for the builds to finish (doesn't output built RPMs",
+        help="Don't wait for the builds to finish (doesn't output built RPMs)",
         action="store_true"
     )
 

--- a/rgo/builders/copr.py
+++ b/rgo/builders/copr.py
@@ -244,20 +244,24 @@ class CoprBuilder(object):
                     if component.build_id:
                         if not component.done:
                             component.build_proxy = self.client.build_proxy.get(component.build_id)
-                            component.done, failed = CoprBuilder._report_build_proxy_and_get_status(
+                            component.done, build_failed = CoprBuilder._report_build_proxy_and_get_status(
                                 component.build_proxy,
                                 component.name)
                             if not component.done:
                                 done = False
+                            if build_failed:
+                                failed = True
                     for override in component.distgit_overrides:
                         if override.build_id:
                             if not override.done:
                                 override.build_proxy = self.client.build_proxy.get(override.build_id)
-                                override.done, failed = CoprBuilder._report_build_proxy_and_get_status(
+                                override.done, build_failed = CoprBuilder._report_build_proxy_and_get_status(
                                         override.build_proxy,
                                         ", ".join(override.chroots) + " distgit-override " + component.name)
                                 if not override.done:
                                     done = False
+                                if build_failed:
+                                    failed = True
                 if done:
                     break
 


### PR DESCRIPTION
Once it is set to `True` it has to remain `True`, we cannot override it back
to `False` even if the next build succeeded.