### PR TITLE
Consistently generate pkg nevra even if the last commit is release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,4 @@ before_install:
   # `sudo apt-get -y python3-rpm` is not sufficient because we're working in virtualenv
   - pip install rpm-py-installer
 install: pip install .
-script: python setup.py test
+script: python -m unittest discover tests/

--- a/README.md
+++ b/README.md
@@ -4,11 +4,7 @@ Manage an overlay repository of RPMs from upstream git.
 
 ## Running unit tests
 
-Without coverage:
-`$ python3 setup.py test`
-
-With coverage:
-`$ python3 setup.py nosetests`
+`$ python3 -m unittest discover tests/`
 
 ## Installation
 

--- a/rgo/component.py
+++ b/rgo/component.py
@@ -115,11 +115,7 @@ class Component(object):
             version, release = self.git.describe(self.name, spec_version=spec_version, version_from=self.version_from)
 
             # Prepare nvr
-            if release == "1":
-                # tagged version, no need to add useless numbers
-                nvr = "{!s}-{!s}".format(self.name, version)
-            else:
-                nvr = "{!s}-{!s}-{!s}".format(self.name, version, release)
+            nvr = "{!s}-{!s}-{!s}".format(self.name, version, release)
 
             # Prepare archive from git (compressed tarball)
             archive = os.path.join(workdir, "{!s}.tar.xz".format(nvr))

--- a/rgo/git.py
+++ b/rgo/git.py
@@ -216,19 +216,6 @@ class Git(object):
             version = "0"
             release = "0.{!s}.{!s}.g{!s}".format(date, commits, hash)
 
-        elif commits == 0:
-            # release
-
-            # we'll set version to git_version
-            # it's a release, we'll set release to 1
-
-            # Example:
-            #    spec:   doesn't matter
-            #    git:    version=1.9; there are no commits after the tag
-            #    result: version=0, release=0.YYYYMMDDhhmmss.3.gcafecafe
-            version = git_version
-            release = "1"
-
         else:
             # release + patches
 

--- a/rpm-gitoverlay.spec
+++ b/rpm-gitoverlay.spec
@@ -9,7 +9,6 @@ Source0:        %{url}/archive/%{version}/%{name}-%{version}.tar.gz
 
 BuildRequires:  python3-devel
 BuildRequires:  python3-setuptools
-BuildRequires:  python3-nose
 BuildRequires:  python3-marshmallow >= 3
 BuildRequires:  python3-marshmallow-enum
 BuildRequires:  rpm-python3
@@ -45,7 +44,7 @@ BuildArch:      noarch
 %py3_install
 
 %check
-%{__python3} setup.py test
+%{__python3} -m unittest discover tests/
 
 %files
 %license COPYING

--- a/setup.py
+++ b/setup.py
@@ -38,8 +38,6 @@ args = dict(
     extras_require={
         "copr": ["beautifulsoup4", "copr", "requests"]
     },
-    tests_require=["nose"] + REQUIRES,
-    test_suite="nose.collector",
     classifiers=[
         "Development Status :: 2 - Pre-Alpha",
         "Intended Audience :: Developers",

--- a/tests/test_alias.py
+++ b/tests/test_alias.py
@@ -16,12 +16,13 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 import io
-from nose import tools
+import unittest
 import marshmallow
 from rgo.alias import Alias, Aliases
 from rgo.schema import AliasSchema
 
-class TestAlias(object):
+
+class TestAlias(unittest.TestCase):
     def test_gitconfig(self):
         data = [{"name": "github", "url": "git@github.com:"}]
         gitconfig = '[url "git@github.com:"]\ninsteadOf = "github:"'
@@ -29,27 +30,27 @@ class TestAlias(object):
         with io.StringIO() as fd:
             result.gitconfig.write(fd)
             fd.seek(0)
-            tools.eq_(fd.read().rstrip(), gitconfig)
+            self.assertEqual(fd.read().rstrip(), gitconfig)
 
     def test_duplicate(self):
         data = [{"name": "foo", "url": "bar"},
                 {"name": "foo", "url": "baz"}]
-        with tools.assert_raises(marshmallow.ValidationError) as ve:
+        with self.assertRaises(marshmallow.ValidationError) as ve:
             AliasSchema(many=True).load(data)
-        tools.eq_(ve.exception.messages, {"name": ["Duplicates found"]})
+        self.assertEqual(ve.exception.messages, {"name": ["Duplicates found"]})
 
     def test_many(self):
         alias = {"name": "foo", "url": "bar"}
-        tools.ok_(isinstance(AliasSchema().load(alias), Alias))
-        tools.ok_(isinstance(AliasSchema(many=True).load([alias]), Aliases))
+        self.assertTrue(isinstance(AliasSchema().load(alias), Alias))
+        self.assertTrue(isinstance(AliasSchema(many=True).load([alias]), Aliases))
 
     def test_builtins(self):
         data = [{"name": "foo", "url": "u1"},
                 {"name": "bar", "url": "u2"}]
         results = AliasSchema(many=True).load(data)
-        tools.eq_(len(results), 2)
-        tools.ok_("foo" in results)
-        tools.ok_("baz" not in results)
-        tools.ok_(results[0] in results)
-        tools.eq_(AliasSchema().dump(results["foo"]), data[0])
-        tools.eq_(AliasSchema().dump(results[1]), data[1])
+        self.assertEqual(len(results), 2)
+        self.assertTrue("foo" in results)
+        self.assertTrue("baz" not in results)
+        self.assertTrue(results[0] in results)
+        self.assertEqual(AliasSchema().dump(results["foo"]), data[0])
+        self.assertEqual(AliasSchema().dump(results[1]), data[1])

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -76,7 +76,7 @@ class TestGit(unittest.TestCase):
         self.tag("1.9")
         ver, rel = repo.describe()
         self.assertEqual(ver, "1.9")
-        self.assertEqual(rel, "1")
+        self.assertRegex(rel, R"[0-9]{{14}}\.0\.g{!s}".format(sha))
 
         # commits after tag
         self.commit("test")
@@ -109,10 +109,21 @@ class TestGit(unittest.TestCase):
         # prefixes
         self.commit("v-prefix")
         self.tag("v0.2")
-        self.assertEqual(repo.describe(), ("0.2", "1"))
+        sha = repo.rev_parse("HEAD", short=True)
+        ver, rel = repo.describe()
+        self.assertEqual(ver, "0.2")
+        self.assertRegex(rel, R"[0-9]{{14}}\.0\.g{!s}".format(sha))
+
         self.commit("GNOME-style (upper)")
         self.tag("GNOME_BUILDER_3_21_1")
-        self.assertEqual(repo.describe("gnome-builder"), ("3.21.1", "1"))
+        sha = repo.rev_parse("HEAD", short=True)
+        ver, rel = repo.describe("gnome-builder")
+        self.assertEqual(ver, "3.21.1")
+        self.assertRegex(rel, R"[0-9]{{14}}\.0\.g{!s}".format(sha))
+
         self.commit("GNOME-style (lower)")
         self.tag("libhif_0_7_0")
-        self.assertEqual(repo.describe("libhif"), ("0.7.0", "1"))
+        sha = repo.rev_parse("HEAD", short=True)
+        ver, rel = repo.describe("libhif")
+        self.assertEqual(ver, "0.7.0")
+        self.assertRegex(rel, R"[0-9]{{14}}\.0\.g{!s}".format(sha))


### PR DESCRIPTION
When upstream's last commit is the release commit we get release == 1 and
RGO generated the package nevra without date and hash, it could look
like a normal fedora release: libdnf-0.66.0-1.fc35.x86_64.rpm.

If the pkg was just released to Fedora both our build and fedora
build would have the same nevra. This means that even if the package is
available it doesn't get upgraded which could be a problem because the
fedora build can contain downstream only patches and thus behave
differently than our RGO build.

This is causing fails in our CI because we test for unpatched behavior
but since libdnf doesn't get upgraded we get a patched build from fedora.