### PR TITLE
Explicitly define %_srcrpmdir

### DIFF
--- a/rgo/component.py
+++ b/rgo/component.py
@@ -160,7 +160,8 @@ class Component(object):
         try:
             result = subprocess.run(["rpmbuild", "-bs", final_spec_path, "--nodeps",
                                      "--define", "_topdir {!s}".format(workdir),
-                                     "--define", "_sourcedir {!s}".format(workdir)],
+                                     "--define", "_sourcedir {!s}".format(workdir),
+                                     "--define", "_srcrpmdir %{_topdir}/SRPMS"],
                                     check=True, universal_newlines=True,
                                     stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
         except subprocess.CalledProcessError as err:


### PR DESCRIPTION
`%_srcrpmdir` is not always `%{_topdir}/SRPMS`. Set it explicitly so rpm-gitoverlay doesn't fail to find the SRPM and blow up.